### PR TITLE
Add Chrome options to run without sandbox and avoid crashes

### DIFF
--- a/xlsNinja.py
+++ b/xlsNinja.py
@@ -717,7 +717,9 @@ try:
                 for response_text, url in done:
                     self.totalScanned += 1
                     chrome_options = Options()
-                    chrome_options.add_argument("--headless") 
+                    chrome_options.add_argument("--headless")
+                    chrome_options.add_argument("--no-sandbox")
+                    chrome_options.add_argument("--disable-dev-shm-usage")
                     service = ChromeService(executable_path=ChromeDriverManager().install())
                     driver = webdriver.Chrome(service=service, options=chrome_options)
 


### PR DESCRIPTION
- Added `--no-sandbox` option to allow Chrome to run as root, which is necessary for XSS detection feature (otherwise, it crashes).
- Added `--disable-dev-shm-usage` option to prevent Chrome crashes related to shared memory usage (/dev/shm), especially when running in Docker environments where shared memory space is limited.