### PR TITLE
Moved most imports to a central place

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 webdriver_manager==4.0.2
 selenium==4.24.0
-aiohttp==3.10.5
-beautifulsoup4==4.12.3
-colorama==0.4.6
-rich==12.6.0
-requests==2.28.1
-prompt_toolkit==3.0.31
+aiohttp
+beautifulsoup4
+colorama
+rich
+requests
+prompt_toolkit

--- a/xlsNinja.py
+++ b/xlsNinja.py
@@ -1,11 +1,43 @@
 # This program was created by: AnonKryptiQuz, Coffinxp Hexsh1dow and Naho
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from curses import panel
-import random
-import re
-from wsgiref import headers
+try:
+    import random
+    import re
+    import os
+    import sys
+    import subprocess
+    import concurrent.futures
+    import time
+    import logging
+    import aiohttp
+    import asyncio
+    import requests
+    import urllib3
+    import urllib.parse
 
+    from rich.panel import Panel
+    from rich import print as rich_print
+    from prompt_toolkit import prompt
+    from colorama import Fore, Style, init
+    from prompt_toolkit.completion import PathCompleter
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from urllib3.util.retry import Retry
+    from urllib.parse import quote, urlencode, parse_qs, urlsplit, urlunsplit, urlparse, urlunparse
+
+    # Apparently not accessed in code
+    # from time import sleep # time.sleep has been used instead of just sleep.
+    # from wsgiref import headers 
+    # from rich.table import Table 
+    # from bs4 import BeautifulSoup 
+    #from curses import panel
+    # import argparse
+    
+
+except:
+    print ("Run `pip install -r requirements.txt --user` to install missing packages")
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 class Color:
     BLUE = '\033[94m'
@@ -21,41 +53,19 @@ class Color:
     ITALIC = '\033[3m'
     UNITALIC = '\033[23m'
 
+
+def clear_screen():
+    os.system('cls' if os.name == 'nt' else 'clear')
+
 try:
-    import os
-    import sys
-    import subprocess
-    from colorama import Fore, Style, init
-    from time import sleep
-    from rich import print as rich_print
-    from rich.panel import Panel
-    from rich.table import Table
-    import concurrent.futures
-    from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
-    from bs4 import BeautifulSoup
-    import time
-    import requests
-    import urllib3
-    from prompt_toolkit import prompt
-    from prompt_toolkit.completion import PathCompleter
-    import subprocess
-    import sys
-    import random
-    from urllib.parse import urlparse, quote
-
-
-
     init(autoreset=True)
 
-    def check_and_install_packages(packages):
-        for package, version in packages.items():
-            try:
-                __import__(package)
-            except ImportError:
-                subprocess.check_call([sys.executable, '-m', 'pip', 'install', f"{package}=={version}"])
-
-    def clear_screen():
-        os.system('cls' if os.name == 'nt' else 'clear')
+    # def check_and_install_packages(packages):
+    #     for package, version in packages.items():
+    #         try:
+    #             __import__(package)
+    #         except ImportError:
+    #             subprocess.check_call([sys.executable, '-m', 'pip', 'install', f"{package}=={version}"])
 
 
 
@@ -120,21 +130,6 @@ try:
 
     def run_sql_scanner():
         try:
-            import requests
-            import logging
-            from requests.adapters import HTTPAdapter
-            from urllib3.util.retry import Retry
-            import urllib3
-            import time
-            import concurrent.futures
-            from colorama import Fore, init
-            import os
-            from prompt_toolkit import prompt
-            from prompt_toolkit.completion import PathCompleter
-            import subprocess
-            import sys
-            import random
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
             init(autoreset=True)
 
@@ -182,15 +177,12 @@ try:
             def get_random_user_agent():
                 return random.choice(USER_AGENTS)
 
-            def check_and_install_packages(packages):
+            """ def check_and_install_packages(packages):
                 for package, version in packages.items():
                     try:
                         __import__(package)
                     except ImportError:
-                        subprocess.check_call([sys.executable, '-m', 'pip', 'install', f"{package}=={version}"])
-
-            def clear_screen():
-                os.system('cls' if os.name == 'nt' else 'clear')
+                        subprocess.check_call([sys.executable, '-m', 'pip', 'install', f"{package}=={version}"]) """
 
             def get_retry_session(retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 504)):
                 session = requests.Session()
@@ -201,7 +193,7 @@ try:
                     backoff_factor=backoff_factor,
                     status_forcelist=status_forcelist,
                 )
-                adapter = HTTPAdapter(max_retries=retry)
+                adapter = requests.adapters.HTTPAdapter(max_retries=retry)
                 session.mount('http://', adapter)
                 session.mount('https://', adapter)
                 return session
@@ -317,23 +309,18 @@ try:
                 print(f"{Fore.YELLOW}[i] Total scanned: {total_scanned}")
                 print(f"{Fore.YELLOW}[i] Time taken: {int(time.time() - start_time)} seconds")
 
-
-
-
-
             def main():
                 clear_screen()
-                required_packages = {
-                    'requests': '2.28.1',
-                    'prompt_toolkit': '3.0.36',
-                    'colorama': '0.4.6'
-                }
+                # required_packages = {
+                    # 'requests': '2.28.1',
+                    # 'prompt_toolkit': '3.0.36',
+                    # 'colorama': '0.4.6'
+                # } 
 
-                check_and_install_packages(required_packages)
+                # check_and_install_packages(required_packages)
 
-
-                time.sleep(3)
-                clear_screen()
+                # time.sleep(3)
+                # clear_screen()
 
                 panel = Panel(
             r"""                                                       
@@ -516,25 +503,7 @@ try:
 
 
     def run_xss_scanner():
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-        import argparse
-        import subprocess
-        import sys
-        import time
-        import aiohttp
-        import asyncio
-        import logging
-        import os
-        from colorama import Fore, init
-        from urllib.parse import urlencode, parse_qs, urlsplit, urlunsplit
-        from prompt_toolkit import prompt
-        from prompt_toolkit.completion import PathCompleter
-        from rich import print as rich_print
-        from rich.panel import Panel
-        from rich.table import Table
-        from requests.adapters import HTTPAdapter
-        from urllib3.util.retry import Retry
         from selenium import webdriver
         from selenium.webdriver.chrome.service import Service as ChromeService
         from selenium.webdriver.common.by import By
@@ -542,7 +511,7 @@ try:
         from selenium.webdriver.support.ui import WebDriverWait
         from selenium.webdriver.support import expected_conditions as EC
         from webdriver_manager.chrome import ChromeDriverManager
-        import logging
+        
         logging.getLogger('WDM').setLevel(logging.ERROR)
 
 
@@ -597,9 +566,6 @@ try:
                 except ImportError:
                     subprocess.check_call([sys.executable, '-m', 'pip', 'install', f"{package}=={version}"])
 
-        def clear_screen():
-            os.system('cls' if os.name == 'nt' else 'clear')
-
 
         def get_random_user_agent():
             return random.choice(USER_AGENTS)
@@ -613,7 +579,7 @@ try:
                 backoff_factor=backoff_factor,
                 status_forcelist=status_forcelist,
             )
-            adapter = HTTPAdapter(max_retries=retry)
+            adapter = requests.adapters.HTTPAdapter(max_retries=retry)
             session.mount('http://', adapter)
             session.mount('https://', adapter)
             return session
@@ -714,7 +680,7 @@ try:
                     return (response_text, url)
 
             def process_tasks(self, done):
-                for response_text, url in done:
+                for response_text, url in done:  # response_text not accessed according to VS Code ?
                     self.totalScanned += 1
                     chrome_options = Options()
                     chrome_options.add_argument("--headless")
@@ -855,17 +821,25 @@ try:
 
         def main():
             clear_screen()
+
+            # Had this enabled at this point because some VPSes don't support having a headless browser install.
             required_packages = {
-                'aiohttp': '3.8.6',
-                'requests': '2.28.1',
-                'prompt_toolkit': '3.0.36',
-                'colorama': '0.4.6'
+                'webdriver-manager',
+                'selenium'
             }
+
+            # required_packages = {
+            #     'aiohttp': '3.8.6',
+            #     'requests': '2.28.1',
+            #     'prompt_toolkit': '3.0.36',
+            #     'colorama': '0.4.6'
+            # }
 
             check_and_install_packages(required_packages)
             
             time.sleep(3)
             clear_screen()
+
             panel = Panel(r"""
    _  __________  ____________   _  ___  __________
   | |/_/ __/ __/ / __/ ___/ _ | / |/ / |/ / __/ _  |
@@ -920,20 +894,6 @@ try:
     def run_or_scanner():
 
         try:
-            import requests
-            import urllib.parse
-            import os
-            import sys
-            import subprocess
-            import logging
-            import time
-            from concurrent.futures import ThreadPoolExecutor, as_completed
-            from prompt_toolkit import prompt
-            from prompt_toolkit.completion import PathCompleter
-            from colorama import Fore, init
-            from requests.adapters import HTTPAdapter
-            from urllib3.util.retry import Retry
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
             init(autoreset=True)
 
@@ -990,7 +950,7 @@ try:
                     backoff_factor=backoff_factor,
                     status_forcelist=status_forcelist,
                 )
-                adapter = HTTPAdapter(max_retries=retry)
+                adapter = requests.adapters.HTTPAdapter(max_retries=retry)
                 session.mount('http://', adapter)
                 session.mount('https://', adapter)
                 return session
@@ -1124,9 +1084,6 @@ try:
                 print(Fore.YELLOW + f"[i] Total scanned: {total_scanned}")
                 print(Fore.YELLOW + f"[i] Time taken: {int(time.time() - start_time)} seconds")
 
-            def clear_screen():
-                os.system('cls' if os.name == 'nt' else 'clear')
-
             def get_file_path(prompt_text):
                 completer = PathCompleter()
                 return prompt(prompt_text, completer=completer).strip()
@@ -1134,15 +1091,15 @@ try:
             def main():
                 clear_screen()
 
-                required_packages = {
-                    'requests': '2.28.1',
-                    'prompt_toolkit': '3.0.36',
-                    'colorama': '0.4.6'
-                }
-                check_and_install_packages(required_packages)
+                # required_packages = {
+                #     'requests': '2.28.1',
+                #     'prompt_toolkit': '3.0.36',
+                #     'colorama': '0.4.6'
+                # }
+                # check_and_install_packages(required_packages)
 
-                time.sleep(3)
-                clear_screen()
+                # time.sleep(3)
+                # clear_screen()
 
 
                 panel = Panel(
@@ -1213,26 +1170,6 @@ try:
 
 
     def run_lfi_scanner():
-       
-
-
-        import requests
-        import urllib.parse
-        import re
-        import os
-        import sys
-        import subprocess
-        import time
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-        from prompt_toolkit import prompt
-        from prompt_toolkit.completion import PathCompleter
-        from colorama import Fore, init
-        import logging
-        from requests.adapters import HTTPAdapter
-        from urllib3.util.retry import Retry
-
-
-
         USER_AGENTS = [
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Version/14.1.2 Safari/537.36",
@@ -1275,18 +1212,17 @@ try:
             'Wallarm': ['x-wallarm-waf-check', 'wallarm'],
         }
 
-
         init(autoreset=True)
 
         def get_random_user_agent():
             return random.choice(USER_AGENTS)
         
-        def check_and_install_packages(packages):
-            for package, version in packages.items():
-                try:
-                    __import__(package)
-                except ImportError:
-                    subprocess.check_call([sys.executable, '-m', 'pip', 'install', f"{package}=={version}"])
+        # def check_and_install_packages(packages):
+        #     for package, version in packages.items():
+        #         try:
+        #             __import__(package)
+        #         except ImportError:
+        #             subprocess.check_call([sys.executable, '-m', 'pip', 'install', f"{package}=={version}"])
 
 
 
@@ -1299,7 +1235,7 @@ try:
                 backoff_factor=backoff_factor,
                 status_forcelist=status_forcelist,
             )
-            adapter = HTTPAdapter(max_retries=retry)
+            adapter = requests.adapters.HTTPAdapter(max_retries=retry)
             session.mount('http://', adapter)
             session.mount('https://', adapter)
             return session
@@ -1427,9 +1363,6 @@ try:
             print(Fore.YELLOW + f"[i] Time taken: {int(time.time() - start_time)} seconds")
             exit()
 
-        def clear_screen():
-            os.system('cls' if os.name == 'nt' else 'clear')
-
         def get_file_path(prompt_text):
             completer = PathCompleter()
             return prompt(prompt_text, completer=completer).strip()
@@ -1437,15 +1370,15 @@ try:
         def main():
             clear_screen()
 
-            required_packages = {
-                'requests': '2.28.1',
-                'prompt_toolkit': '3.0.36',
-                'colorama': '0.4.6'
-            }
-            check_and_install_packages(required_packages)
+            # required_packages = {
+            #     'requests': '2.28.1',
+            #     'prompt_toolkit': '3.0.36',
+            #     'colorama': '0.4.6'
+            # }
+            # check_and_install_packages(required_packages)
 
-            time.sleep(3)
-            clear_screen()
+            # time.sleep(3)
+            # clear_screen()
 
             panel = Panel(
             r"""
@@ -1528,6 +1461,7 @@ try:
         elif selection == '4':
             clear_screen()
             run_xss_scanner()
+
         elif selection == '5':
             clear_screen()
             print_exit_menu()
@@ -1537,17 +1471,17 @@ try:
 
     def main():
         clear_screen()
-        required_packages = {
-            'aiohttp': '3.8.6',
-            'requests': '2.28.1',
-            'prompt_toolkit': '3.0.36',
-            'colorama': '0.4.6'
-        }
+        # required_packages = {
+        #     'aiohttp': '3.8.6',
+        #     'requests': '2.28.1',
+        #     'prompt_toolkit': '3.0.36',
+        #     'colorama': '0.4.6'
+        # }
 
-        check_and_install_packages(required_packages)
+        # check_and_install_packages(required_packages)
 
-        sleep(3)
-        clear_screen()
+        # sleep(3)
+        # clear_screen()
 
         while True:
             display_menu()


### PR DESCRIPTION
Hello, Nice tool you have here.

1. I have moved most imports to the beginning of the file. This is to prevent multiple re-importing packages unnecessarily
2. I have removed version requirements from requirements.txt file for most packages which isn't necessary. Such imports only matter if you are one of those python supercoders and you are using niche features from certain version and/or a package update might break your code (highly unlikely for us normies).

Also, check on the function at line 682 in this code after pr or 717 in your code before this pr, response_text isn't being accessed.


Regards.